### PR TITLE
fix mcrypt

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -8,12 +8,15 @@ RUN apt-get update && apt-get install -y \
 	libjpeg62-turbo-dev \
 	libmcrypt-dev \
 	libpng-dev \
+	libzip-dev \
     curl
+
+RUN apt-get install -y libmcrypt-dev
+RUN pecl install mcrypt-1.0.2 && docker-php-ext-enable mcrypt
 
 # Install extensions using the helper script provided by the base image
 RUN docker-php-ext-install \
 	zip \
-	mcrypt \
 	pdo_mysql \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
 	&& docker-php-ext-install -j$(nproc) gd


### PR DESCRIPTION
problem with mcrypt

When start project with docker  `$ docker-compose up -d apache mysql` get error:

```bash
error: /usr/src/php/ext/mcrypt does not exist

usage: /usr/local/bin/docker-php-ext-install [-jN] [--ini-name file.ini] ext-name [ext-name ...]
   ie: /usr/local/bin/docker-php-ext-install gd mysqli
       /usr/local/bin/docker-php-ext-install pdo pdo_mysql
       /usr/local/bin/docker-php-ext-install -j5 gd mbstring mysqli pdo pdo_mysql shmop

if custom ./configure arguments are necessary, see docker-php-ext-configure

Possible values for ext-name:
bcmath bz2 calendar ctype curl dba dom enchant exif fileinfo filter ftp gd gettext gmp hash iconv imap interbase intl json ldap mbstring mysqli oci8 odbc opcache pcntl pdo pdo_dblib pdo_firebird pdo_mysql pdo_oci pdo_odbc pdo_pgsql pdo_sqlite pgsql phar posix pspell readline recode reflection session shmop simplexml snmp soap sockets sodium spl standard sysvmsg sysvsem sysvshm tidy tokenizer wddx xml xmlreader xmlrpc xmlwriter xsl zend_test zip

Some of the above modules are already compiled into PHP; please check
the output of "php -i" to see which modules are already loaded.
ERROR: Service 'php-fpm' failed to build: The command '/bin/sh -c docker-php-ext-install 	zip 	mcrypt 	pdo_mysql     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ 	&& docker-php-ext-install -j$(nproc) gd' returned a non-zero code: 1
```

with this change everything works fine @mattythebatty 