### PR TITLE
Update to use php8

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm
+FROM php:8.0-fpm
 
 ADD ./opencart.ini /usr/local/etc/php/conf.d
 ADD ./opencart.pool.conf /usr/local/etc/php-fpm.d/
@@ -12,13 +12,13 @@ RUN apt-get update && apt-get install -y \
     curl
 
 RUN apt-get install -y libmcrypt-dev
-RUN pecl install mcrypt-1.0.2 && docker-php-ext-enable mcrypt
+RUN pecl install mcrypt-1.0.4 && docker-php-ext-enable mcrypt
 
 # Install extensions using the helper script provided by the base image
 RUN docker-php-ext-install \
 	zip \
 	pdo_mysql \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
 	&& docker-php-ext-install -j$(nproc) gd \
 	&& docker-php-ext-install mysqli
 


### PR DESCRIPTION
Proposed config change to update to php8 and resolve Issue #15 .  Update Dockerfile to start with base image 8.0-fpm. This required corresponding changes to build successfully: 
- advance version of `mcrypt` from `1.0.2` to `1.0.4`
- rename options for `docker-php-ext-configure gd`